### PR TITLE
Increase default log level from debug to info (#349)

### DIFF
--- a/.circleci/Dockerfile-scionHost
+++ b/.circleci/Dockerfile-scionHost
@@ -6,7 +6,8 @@ RUN apt-get update && apt-get install --assume-yes \
   sudo \
   apt-transport-https \
   openssh-server \
-  jq
+  jq \
+  curl
 
 # systemd
 # Based on: https://developers.redhat.com/blog/2014/05/05/running-systemd-within-docker-container/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,9 +46,9 @@ check_scion_connections: &check_scion_connections
 
     # Wait for 3 beacons received from now on
     docker-compose exec -T as1303 /bin/bash -c \
-      "journalctl -n 0 -f -u scion-control-service@cs-1.service | awk '/Registered beacons/ {c++; if(c>=3) exit(0)}'"
+      "while curl -s 127.0.0.1:30454/metrics | egrep -q 'control_beaconing_received_beacons_total{.*}.[0]+'; do sleep 1; done"
     docker-compose exec -T as1305 /bin/bash -c \
-      "journalctl -n 0 -f -u scion-control-service@cs-1.service | awk '/Registered beacons/ {c++; if(c>=3) exit(0)}'"
+      "while curl -s 127.0.0.1:30454/metrics | egrep -q 'control_beaconing_received_beacons_total{.*}.[0]+'; do sleep 1; done"
 
     # Show paths used by SCMP
     docker-compose exec --user user -T as1301 scion showpaths 19-ffaa:0:1303
@@ -275,7 +275,7 @@ jobs:
             # Wait for client to be setup
             echo "Waiting for beaconing before starting VPN client SCMPs"
             docker-compose exec useras4 /bin/bash -c \
-             "journalctl -n 0 -f -u scion-control-service@cs-1.service | awk '/Registered beacons/ {c++; if(c>=3) exit(0)}'; \
+             "while curl -s 127.0.0.1:30454/metrics | egrep -q 'control_beaconing_received_beacons_total{.*}.[0]+'; do sleep 1; done; sleep 5; \
               scion ping -c 5 20-ffaa:0:1405,127.0.0.1"
 
   upgrade_integration:

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
-static_bin/scion-pki filter=lfs diff=lfs merge=lfs -text
+static_bin/scion-pki-darwin-amd64 filter=lfs diff=lfs merge=lfs -text
+static_bin/scion-pki-linux-amd64 filter=lfs diff=lfs merge=lfs -text

--- a/scionlab/scion/config.py
+++ b/scionlab/scion/config.py
@@ -382,7 +382,7 @@ class _ConfigBuilder:
         return {
             'log': {
                 'console': {
-                    'level': 'debug',
+                    'level': 'info',
                 },
             },
         }

--- a/scionlab/tests/data/test_config_tar/host_1.yml
+++ b/scionlab/tests/data/test_config_tar/host_1.yml
@@ -11,7 +11,7 @@ etc/scion/br-1.toml: |
   prometheus = "127.0.0.1:30401"
 
   [log.console]
-  level = "debug"
+  level = "info"
 etc/scion/certs/ISD17-B1-S1.trc: !!binary |
   MIIMCgYJKoZIhvcNAQcCoIIL+zCCC/cCAQExDTALBglghkgBZQMEAgMwgghzBgkqhkiG9w0BBwGg
   gghkBIIIYDCCCFwCAQAwCQIBEQIBAQIBATAiGA8yMDIwMTEyNzEzMjQ1MloYDzIwMjIxMTI3MTMy
@@ -452,7 +452,7 @@ etc/scion/cs-1.toml: |
   propagation = "/etc/scion/beacon_policy.yaml"
 
   [log.console]
-  level = "debug"
+  level = "info"
 etc/scion/keys/master0.key: |-
   ww8zXboQPrgpfJ7QGBjOvw==
 etc/scion/keys/master1.key: |-
@@ -520,7 +520,7 @@ scionlab-config.json: |-
   {
     "files": {
       "etc/scion/beacon_policy.yaml": "90c69ea879ca52546774c3007e7d29104766fc07",
-      "etc/scion/br-1.toml": "3940948bd3850f080ccf24922a8e1c4862129f1d",
+      "etc/scion/br-1.toml": "93b34c926178d1ea7c422d7d9fa2d8d7dd770d3b",
       "etc/scion/certs/ISD17-B1-S1.trc": "69955adde1383f6996656cf0b41d07c485a5a4fc",
       "etc/scion/certs/ISD19-B1-S1.trc": "8a82241f811eb1d68bae427a3821ea7a9c7d40c0",
       "etc/scion/certs/ISD20-B1-S1.trc": "bc54e36782e4a472bc47b4b0586d516b68c45c33",
@@ -534,7 +534,7 @@ scionlab-config.json: |-
       "etc/scion/crypto/voting/ISD17-ASffaa_0_1101.sensitive.crt": "c8ef4fbdede2e2696302813ffc856a2a1a9c5619",
       "etc/scion/crypto/voting/regular-voting.key": "344a51b11cc51a5e473ea0ae7234c9a1e3d4549f",
       "etc/scion/crypto/voting/sensitive-voting.key": "400aee636c2f5a330ac7d7d02595b8286054e1ba",
-      "etc/scion/cs-1.toml": "845b9417f2085abd1e97791e982ce8b882ff9dea",
+      "etc/scion/cs-1.toml": "29acf3f22d998849dda271314af17f3ecfdbc9d8",
       "etc/scion/keys/master0.key": "33e60676f471fc79fa446cdb4e5fc79c0a9b8ed6",
       "etc/scion/keys/master1.key": "33e60676f471fc79fa446cdb4e5fc79c0a9b8ed6",
       "etc/scion/topology.json": "d98ff25307e2eda82b43957ef622e550831dc324"

--- a/scionlab/tests/data/test_config_tar/host_16.yml
+++ b/scionlab/tests/data/test_config_tar/host_16.yml
@@ -134,7 +134,7 @@ etc/scion/br-1.toml: |
   prometheus = "127.0.0.1:30401"
 
   [log.console]
-  level = "debug"
+  level = "info"
 etc/scion/certs/ISD17-B1-S1.trc: !!binary |
   MIIMCgYJKoZIhvcNAQcCoIIL+zCCC/cCAQExDTALBglghkgBZQMEAgMwgghzBgkqhkiG9w0BBwGg
   gghkBIIIYDCCCFwCAQAwCQIBEQIBAQIBATAiGA8yMDIwMTEyNzEzMjQ1MloYDzIwMjIxMTI3MTMy
@@ -477,7 +477,7 @@ etc/scion/cs-1.toml: |
   propagation = "/etc/scion/beacon_policy.yaml"
 
   [log.console]
-  level = "debug"
+  level = "info"
 etc/scion/keys/master0.key: |-
   Ck/bstgBkvvpIx4w/Yvrog==
 etc/scion/keys/master1.key: |-
@@ -527,13 +527,13 @@ scionlab-config.json: |-
     "files": {
       "etc/openvpn/client-scionlab-17-ffaa_0_1107.conf": "f97099108aabfd9a62c72aad342d5ecca1b5c736",
       "etc/scion/beacon_policy.yaml": "90c69ea879ca52546774c3007e7d29104766fc07",
-      "etc/scion/br-1.toml": "3940948bd3850f080ccf24922a8e1c4862129f1d",
+      "etc/scion/br-1.toml": "93b34c926178d1ea7c422d7d9fa2d8d7dd770d3b",
       "etc/scion/certs/ISD17-B1-S1.trc": "69955adde1383f6996656cf0b41d07c485a5a4fc",
       "etc/scion/certs/ISD19-B1-S1.trc": "8a82241f811eb1d68bae427a3821ea7a9c7d40c0",
       "etc/scion/certs/ISD20-B1-S1.trc": "bc54e36782e4a472bc47b4b0586d516b68c45c33",
       "etc/scion/crypto/as/ISD17-ASffaa_1_1.pem": "032d301aeee0b30b33909088ad5f9541feaa1199",
       "etc/scion/crypto/as/cp-as.key": "90d9b466c3b3938c7fcd5e5eaf5b74950f42b1ee",
-      "etc/scion/cs-1.toml": "0ef56839347bcb4cdef6c814ff2e1af86cbe8c89",
+      "etc/scion/cs-1.toml": "971405d2fe08e2a2a7f6f7ad259dbd3d8746fd79",
       "etc/scion/keys/master0.key": "a7bfc5d614d0a403bf1d602e05126c962f6a1572",
       "etc/scion/keys/master1.key": "a7bfc5d614d0a403bf1d602e05126c962f6a1572",
       "etc/scion/topology.json": "30b9d338dccff233ce597d95ce6a838d5bd44c0a"

--- a/scionlab/tests/data/test_config_tar/host_17.yml
+++ b/scionlab/tests/data/test_config_tar/host_17.yml
@@ -11,7 +11,7 @@ etc/scion/br-1.toml: |
   prometheus = "127.0.0.1:30401"
 
   [log.console]
-  level = "debug"
+  level = "info"
 etc/scion/certs/ISD17-B1-S1.trc: !!binary |
   MIIMCgYJKoZIhvcNAQcCoIIL+zCCC/cCAQExDTALBglghkgBZQMEAgMwgghzBgkqhkiG9w0BBwGg
   gghkBIIIYDCCCFwCAQAwCQIBEQIBAQIBATAiGA8yMDIwMTEyNzEzMjQ1MloYDzIwMjIxMTI3MTMy
@@ -354,7 +354,7 @@ etc/scion/cs-1.toml: |
   propagation = "/etc/scion/beacon_policy.yaml"
 
   [log.console]
-  level = "debug"
+  level = "info"
 etc/scion/keys/master0.key: |-
   IEXT5uwrnGk2Q04EdUaNnA==
 etc/scion/keys/master1.key: |-
@@ -404,13 +404,13 @@ scionlab-config.json: |-
   {
     "files": {
       "etc/scion/beacon_policy.yaml": "90c69ea879ca52546774c3007e7d29104766fc07",
-      "etc/scion/br-1.toml": "3940948bd3850f080ccf24922a8e1c4862129f1d",
+      "etc/scion/br-1.toml": "93b34c926178d1ea7c422d7d9fa2d8d7dd770d3b",
       "etc/scion/certs/ISD17-B1-S1.trc": "69955adde1383f6996656cf0b41d07c485a5a4fc",
       "etc/scion/certs/ISD19-B1-S1.trc": "8a82241f811eb1d68bae427a3821ea7a9c7d40c0",
       "etc/scion/certs/ISD20-B1-S1.trc": "bc54e36782e4a472bc47b4b0586d516b68c45c33",
       "etc/scion/crypto/as/ISD19-ASffaa_1_2.pem": "d6fbc12fbd511bab2cfaa7b50a77bba772d98bc2",
       "etc/scion/crypto/as/cp-as.key": "06249087fc2b136cdb43c1d895863324da6a96f3",
-      "etc/scion/cs-1.toml": "0ef56839347bcb4cdef6c814ff2e1af86cbe8c89",
+      "etc/scion/cs-1.toml": "971405d2fe08e2a2a7f6f7ad259dbd3d8746fd79",
       "etc/scion/keys/master0.key": "f7b29d38720e6ea830487035b9556a1df2f4d0f9",
       "etc/scion/keys/master1.key": "f7b29d38720e6ea830487035b9556a1df2f4d0f9",
       "etc/scion/topology.json": "5c061e2995f336aebcb64f06b25da87684e8c2b8"

--- a/scionlab/tests/data/test_config_tar/host_4.yml
+++ b/scionlab/tests/data/test_config_tar/host_4.yml
@@ -140,7 +140,7 @@ etc/scion/br-1.toml: |
   prometheus = "127.0.0.1:30401"
 
   [log.console]
-  level = "debug"
+  level = "info"
 etc/scion/br-2.toml: |
   [general]
   config_dir = "/etc/scion"
@@ -151,7 +151,7 @@ etc/scion/br-2.toml: |
   prometheus = "127.0.0.1:30402"
 
   [log.console]
-  level = "debug"
+  level = "info"
 etc/scion/certs/ISD17-B1-S1.trc: !!binary |
   MIIMCgYJKoZIhvcNAQcCoIIL+zCCC/cCAQExDTALBglghkgBZQMEAgMwgghzBgkqhkiG9w0BBwGg
   gghkBIIIYDCCCFwCAQAwCQIBEQIBAQIBATAiGA8yMDIwMTEyNzEzMjQ1MloYDzIwMjIxMTI3MTMy
@@ -494,7 +494,7 @@ etc/scion/cs-1.toml: |
   propagation = "/etc/scion/beacon_policy.yaml"
 
   [log.console]
-  level = "debug"
+  level = "info"
 etc/scion/keys/master0.key: |-
   kNjHXalqKVkXu7W9qbR8iA==
 etc/scion/keys/master1.key: |-
@@ -565,14 +565,14 @@ scionlab-config.json: |-
       "etc/openvpn/ccd/exbert@scionlab.org_ffaa_1_1": "72a44b475588d54d168220d99cb1d5b26a39decd",
       "etc/openvpn/server.conf": "97ea92112ee068f1843ae7691382c5fc2e76e977",
       "etc/scion/beacon_policy.yaml": "90c69ea879ca52546774c3007e7d29104766fc07",
-      "etc/scion/br-1.toml": "3940948bd3850f080ccf24922a8e1c4862129f1d",
-      "etc/scion/br-2.toml": "27fb7b6e1996b6d85a600f61598255706f72542c",
+      "etc/scion/br-1.toml": "93b34c926178d1ea7c422d7d9fa2d8d7dd770d3b",
+      "etc/scion/br-2.toml": "3e4c3c9c65f706f6792830ce68e3ae0d6b394a1f",
       "etc/scion/certs/ISD17-B1-S1.trc": "69955adde1383f6996656cf0b41d07c485a5a4fc",
       "etc/scion/certs/ISD19-B1-S1.trc": "8a82241f811eb1d68bae427a3821ea7a9c7d40c0",
       "etc/scion/certs/ISD20-B1-S1.trc": "bc54e36782e4a472bc47b4b0586d516b68c45c33",
       "etc/scion/crypto/as/ISD17-ASffaa_0_1107.pem": "123c2ecf9e906796dac527c1d1cbe56ad6c3f493",
       "etc/scion/crypto/as/cp-as.key": "012a8b8508ce0d781daa3955da57ae531c80b90c",
-      "etc/scion/cs-1.toml": "0ef56839347bcb4cdef6c814ff2e1af86cbe8c89",
+      "etc/scion/cs-1.toml": "971405d2fe08e2a2a7f6f7ad259dbd3d8746fd79",
       "etc/scion/keys/master0.key": "77ed94fae8197e32b7e56a3b8804551d781b6663",
       "etc/scion/keys/master1.key": "77ed94fae8197e32b7e56a3b8804551d781b6663",
       "etc/scion/topology.json": "6e46bdf5f1692c7e6b4ba258560c330023e54a59"

--- a/scionlab/tests/data/test_config_tar/user_as_18.yml
+++ b/scionlab/tests/data/test_config_tar/user_as_18.yml
@@ -13,7 +13,7 @@ etc/scion/br-1.toml: |
   prometheus = "127.0.0.1:30401"
 
   [log.console]
-  level = "debug"
+  level = "info"
 etc/scion/certs/ISD17-B1-S1.trc: !!binary |
   MIIMCgYJKoZIhvcNAQcCoIIL+zCCC/cCAQExDTALBglghkgBZQMEAgMwgghzBgkqhkiG9w0BBwGg
   gghkBIIIYDCCCFwCAQAwCQIBEQIBAQIBATAiGA8yMDIwMTEyNzEzMjQ1MloYDzIwMjIxMTI3MTMy
@@ -356,7 +356,7 @@ etc/scion/cs-1.toml: |
   propagation = "/etc/scion/beacon_policy.yaml"
 
   [log.console]
-  level = "debug"
+  level = "info"
 etc/scion/keys/master0.key: |-
   MCQgtuWgUs081jQWnFgiWA==
 etc/scion/keys/master1.key: |-
@@ -405,13 +405,13 @@ scionlab-config.json: |-
   {
     "files": {
       "etc/scion/beacon_policy.yaml": "90c69ea879ca52546774c3007e7d29104766fc07",
-      "etc/scion/br-1.toml": "3940948bd3850f080ccf24922a8e1c4862129f1d",
+      "etc/scion/br-1.toml": "93b34c926178d1ea7c422d7d9fa2d8d7dd770d3b",
       "etc/scion/certs/ISD17-B1-S1.trc": "69955adde1383f6996656cf0b41d07c485a5a4fc",
       "etc/scion/certs/ISD19-B1-S1.trc": "8a82241f811eb1d68bae427a3821ea7a9c7d40c0",
       "etc/scion/certs/ISD20-B1-S1.trc": "bc54e36782e4a472bc47b4b0586d516b68c45c33",
       "etc/scion/crypto/as/ISD20-ASffaa_1_3.pem": "c448c33b8f63dc26a203a1b626e969bda271eeb9",
       "etc/scion/crypto/as/cp-as.key": "7dce2fffd03ee4a0277bd43c9b438b4fbe972ebe",
-      "etc/scion/cs-1.toml": "0ef56839347bcb4cdef6c814ff2e1af86cbe8c89",
+      "etc/scion/cs-1.toml": "971405d2fe08e2a2a7f6f7ad259dbd3d8746fd79",
       "etc/scion/keys/master0.key": "2601ba8e8bbc7e9344e2d5a2a09c4e9ba9ac3bb7",
       "etc/scion/keys/master1.key": "2601ba8e8bbc7e9344e2d5a2a09c4e9ba9ac3bb7",
       "etc/scion/topology.json": "8bd681097537472c8e750c0eefd2f6a32413c674"

--- a/scionlab/tests/data/test_config_tar/user_as_19.yml
+++ b/scionlab/tests/data/test_config_tar/user_as_19.yml
@@ -136,7 +136,7 @@ etc/scion/br-1.toml: |
   prometheus = "127.0.0.1:30401"
 
   [log.console]
-  level = "debug"
+  level = "info"
 etc/scion/certs/ISD17-B1-S1.trc: !!binary |
   MIIMCgYJKoZIhvcNAQcCoIIL+zCCC/cCAQExDTALBglghkgBZQMEAgMwgghzBgkqhkiG9w0BBwGg
   gghkBIIIYDCCCFwCAQAwCQIBEQIBAQIBATAiGA8yMDIwMTEyNzEzMjQ1MloYDzIwMjIxMTI3MTMy
@@ -479,7 +479,7 @@ etc/scion/cs-1.toml: |
   propagation = "/etc/scion/beacon_policy.yaml"
 
   [log.console]
-  level = "debug"
+  level = "info"
 etc/scion/keys/master0.key: |-
   hMsEcqRlzl/UBqhtVd6N3w==
 etc/scion/keys/master1.key: |-
@@ -529,13 +529,13 @@ scionlab-config.json: |-
     "files": {
       "etc/openvpn/client-scionlab-20-ffaa_0_1405.conf": "9bc818dd6bd01062ee94bbf06031d1a512619716",
       "etc/scion/beacon_policy.yaml": "90c69ea879ca52546774c3007e7d29104766fc07",
-      "etc/scion/br-1.toml": "3940948bd3850f080ccf24922a8e1c4862129f1d",
+      "etc/scion/br-1.toml": "93b34c926178d1ea7c422d7d9fa2d8d7dd770d3b",
       "etc/scion/certs/ISD17-B1-S1.trc": "69955adde1383f6996656cf0b41d07c485a5a4fc",
       "etc/scion/certs/ISD19-B1-S1.trc": "8a82241f811eb1d68bae427a3821ea7a9c7d40c0",
       "etc/scion/certs/ISD20-B1-S1.trc": "bc54e36782e4a472bc47b4b0586d516b68c45c33",
       "etc/scion/crypto/as/ISD20-ASffaa_1_4.pem": "29691eac205fded84b56a40c76d8069b65c5c0b1",
       "etc/scion/crypto/as/cp-as.key": "7b5e5381fe0b7f7101ac348bb079cd01920a717c",
-      "etc/scion/cs-1.toml": "0ef56839347bcb4cdef6c814ff2e1af86cbe8c89",
+      "etc/scion/cs-1.toml": "971405d2fe08e2a2a7f6f7ad259dbd3d8746fd79",
       "etc/scion/keys/master0.key": "69fd53199b210dcda035c219bb1620b0096abbad",
       "etc/scion/keys/master1.key": "69fd53199b210dcda035c219bb1620b0096abbad",
       "etc/scion/topology.json": "10adb3f8f59148d0323cb09bd275fec94c7d3980"

--- a/scionlab/tests/data/test_config_tar/user_as_20.yml
+++ b/scionlab/tests/data/test_config_tar/user_as_20.yml
@@ -13,7 +13,7 @@ gen/ASffaa_1_5/br-1.toml: |
   prometheus = "127.0.0.1:30401"
 
   [log.console]
-  level = "debug"
+  level = "info"
 gen/ASffaa_1_5/certs/ISD17-B1-S1.trc: !!binary |
   MIIMCgYJKoZIhvcNAQcCoIIL+zCCC/cCAQExDTALBglghkgBZQMEAgMwgghzBgkqhkiG9w0BBwGg
   gghkBIIIYDCCCFwCAQAwCQIBEQIBAQIBATAiGA8yMDIwMTEyNzEzMjQ1MloYDzIwMjIxMTI3MTMy
@@ -356,7 +356,7 @@ gen/ASffaa_1_5/cs-1.toml: |
   propagation = "gen/ASffaa_1_5/beacon_policy.yaml"
 
   [log.console]
-  level = "debug"
+  level = "info"
 gen/ASffaa_1_5/keys/master0.key: |-
   a3IkBigxqU18UH+93pvNag==
 gen/ASffaa_1_5/keys/master1.key: |-
@@ -377,7 +377,7 @@ gen/ASffaa_1_5/sd.toml: |
   connection = "gen-cache/sd.trust.db"
 
   [log.console]
-  level = "debug"
+  level = "info"
 gen/ASffaa_1_5/topology.json: |-
   {
     "attributes": [],
@@ -427,7 +427,7 @@ gen/dispatcher/disp.toml: |
   prometheus = "127.0.0.1:30441"
 
   [log.console]
-  level = "debug"
+  level = "info"
 gen/supervisord.conf: |+
   [program:br-1]
   autostart = false

--- a/static_bin/Dockerfile
+++ b/static_bin/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.14.9-buster
 
-# netsec-ethz/scion:scionlab_nextversion, 2020/12/02
-ARG scion_commit=65fd6eb4ec9935018fc643b37f08c868547d325c
+# netsec-ethz/scion, last release on 2020/12/08
+ARG scion_commit=v2020.12
 
 RUN mkdir /scion
 WORKDIR /scion
@@ -12,6 +12,11 @@ RUN git init && \
     git -c advice.detachedHead=false checkout $scion_commit
 
 RUN startup_version=$(git describe --tags --always)-scionlab && \
-    go build -ldflags="-s -w -X github.com/scionproto/scion/go/lib/env.StartupVersion=$startup_version" \
-             -o bin/ \
+    GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X github.com/scionproto/scion/go/lib/env.StartupVersion=$startup_version" \
+             -o bin/scion-pki-linux-amd64 \
+             ./go/scion-pki
+
+RUN startup_version=$(git describe --tags --always)-scionlab && \
+    GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w -X github.com/scionproto/scion/go/lib/env.StartupVersion=$startup_version" \
+             -o bin/scion-pki-darwin-amd64 \
              ./go/scion-pki

--- a/static_bin/build.sh
+++ b/static_bin/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Copyright 2020 ETH Zurich
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,9 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cd `dirname $0`
+cd "$(dirname "$0")" || return
 docker build -t scionlab-scion-pki-build - < Dockerfile
 cid="$(docker create scionlab-scion-pki-build)"
-docker cp "$cid":/scion/bin/scion-pki .
+docker cp "$cid":/scion/bin/scion-pki-linux-amd64  .
+docker cp "$cid":/scion/bin/scion-pki-darwin-amd64 .
 docker rm -v "$cid"
 docker image rm scionlab-scion-pki-build

--- a/static_bin/scion-pki
+++ b/static_bin/scion-pki
@@ -1,3 +1,17 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b9a3db4615a1909dbb35d348c6caa6127b4a28d5f3f28c650762e9b8035b33c9
-size 20312064
+#!/bin/sh
+
+goos=$(uname -s | tr '[:upper:]' '[:lower:]')
+goarch=$(uname -m | tr '[:upper:]' '[:lower:]')
+
+if [ "${goarch}" = "x86_64" ]; then
+   goarch="amd64"
+fi
+
+filename="$(dirname "$0")/scion-pki-${goos}-${goarch}"
+
+if [ ! -e "${filename}" ]; then
+  echo "Unsupported system: ${goos}-${goarch}"
+  exit 1
+fi
+
+exec "${filename}" "$@"

--- a/static_bin/scion-pki-darwin-amd64
+++ b/static_bin/scion-pki-darwin-amd64
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e1d1d3f6685e14a166e2f2736349d255935d8100844d555c457a256799ee01c
+size 23089200

--- a/static_bin/scion-pki-linux-amd64
+++ b/static_bin/scion-pki-linux-amd64
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:87fd59c6b59b5991c23559386ff827336b6aa45b65de6df93a52abc356017ae2
+size 20852736


### PR DESCRIPTION
* compile separate binary for mac and add a shim script

* increase default log level to info

* integration tests use metrics instead of debug logs to determine liveness

* posix compatible scripts; dynamic execution based on system & machine